### PR TITLE
Add mona API ingestion and Panther upload job REST API

### DIFF
--- a/services/panther/README.md
+++ b/services/panther/README.md
@@ -50,6 +50,30 @@ $ python src/panther/main.py upload-documents \
   --use-hash-guard \
   --refresh
 
+### mona REST API からドキュメントを取得してアップロード
+`--mona-base-url` を指定すると、ローカルファイルの代わりに mona API (`/idList`, `/{doc_id}/json/*`) から取得してアップロードする。
+
+```bash
+$ python src/panther/main.py upload-documents \
+  --index patent-documents \
+  --mona-base-url http://mona:8000 \
+  --use-hash-guard \
+  --refresh
+```
+
+### Panther REST API サーバー
+`panther.server:app` を起動すると、ジョブ実行 API を提供する。
+
+```bash
+$ uvicorn panther.server:app --host 0.0.0.0 --port 8080
+```
+
+- `POST /jobs` : 新規アップロードジョブ開始
+- `GET /jobs` : 現在の実行状況（running/latest）
+- `GET /jobs/list` : 過去ジョブID一覧
+- `GET /jobs/{job_id}` : 指定ジョブの詳細
+- `GET /jobs/{job_id}/cancel` : 実行中ジョブのキャンセル要求
+
 ### 付加データのインポートとアップロード
 #### 付加データ用データベースの初期化
 ```bash

--- a/services/panther/src/panther/server.py
+++ b/services/panther/src/panther/server.py
@@ -1,0 +1,191 @@
+import argparse
+import logging
+import os
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from panther.upload_documents import UploadCancelledError, execute_upload
+
+logger = logging.getLogger(__name__)
+
+
+class JobRequest(BaseModel):
+    index: str = Field(default_factory=lambda: os.getenv("ES_INDEX", ""))
+    mona_base_url: str = Field(
+        default_factory=lambda: os.getenv("MONA_BASE_URL", "http://localhost:8000")
+    )
+    es: str = Field(default_factory=lambda: os.getenv("ES_URL", "http://localhost:9200"))
+    api_key: str | None = Field(default_factory=lambda: os.getenv("ES_API_KEY"))
+    user: str | None = Field(default_factory=lambda: os.getenv("ES_USER"))
+    password: str | None = Field(default_factory=lambda: os.getenv("ES_PASSWORD"))
+    pipeline: str | None = Field(default_factory=lambda: os.getenv("ES_PIPELINE"))
+    chunk_size: int = 500
+    max_retries: int = 5
+    use_hash_guard: bool = False
+    refresh: bool = False
+
+
+class JobStatus(BaseModel):
+    job_id: str
+    status: Literal["running", "completed", "failed", "cancelled"]
+    started_at: str
+    finished_at: str | None = None
+    total: int = 0
+    success: int = 0
+    failed: int = 0
+    source: str | None = None
+    error: str | None = None
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+class JobManager:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._jobs: dict[str, JobStatus] = {}
+        self._cancel_events: dict[str, threading.Event] = {}
+        self._running_job_id: str | None = None
+
+    def start_job(self, request: JobRequest) -> JobStatus:
+        with self._lock:
+            if self._running_job_id:
+                raise HTTPException(status_code=409, detail="Another job is already running")
+
+            if not request.index:
+                raise HTTPException(status_code=400, detail="index is required")
+
+            job_id = str(uuid.uuid4())
+            status = JobStatus(job_id=job_id, status="running", started_at=utc_now_iso())
+            self._jobs[job_id] = status
+            cancel_event = threading.Event()
+            self._cancel_events[job_id] = cancel_event
+            self._running_job_id = job_id
+
+        worker = threading.Thread(
+            target=self._run_job, args=(job_id, request, cancel_event), daemon=True
+        )
+        worker.start()
+        return status
+
+    def _run_job(self, job_id: str, request: JobRequest, cancel_event: threading.Event) -> None:
+        try:
+            args = argparse.Namespace(
+                data_root="data",
+                mona_base_url=request.mona_base_url,
+                index=request.index,
+                pipeline=request.pipeline,
+                chunk_size=request.chunk_size,
+                max_retries=request.max_retries,
+                use_hash_guard=request.use_hash_guard,
+                refresh=request.refresh,
+                es=request.es,
+                api_key=request.api_key,
+                user=request.user,
+                password=request.password,
+            )
+            result = execute_upload(args, should_cancel=cancel_event.is_set)
+            new_status = JobStatus(
+                job_id=job_id,
+                status="completed",
+                started_at=self._jobs[job_id].started_at,
+                finished_at=utc_now_iso(),
+                total=int(result["total"]),
+                success=int(result["success"]),
+                failed=int(result["failed"]),
+                source=str(result["source"]),
+            )
+            self._update_job(job_id, new_status)
+        except UploadCancelledError:
+            cancelled = self._jobs[job_id].model_copy(
+                update={"status": "cancelled", "finished_at": utc_now_iso()}
+            )
+            self._update_job(job_id, cancelled)
+        except Exception as exc:
+            failed = self._jobs[job_id].model_copy(
+                update={
+                    "status": "failed",
+                    "finished_at": utc_now_iso(),
+                    "error": str(exc),
+                }
+            )
+            self._update_job(job_id, failed)
+            logger.exception("job failed: %s", job_id)
+        finally:
+            with self._lock:
+                if self._running_job_id == job_id:
+                    self._running_job_id = None
+
+    def _update_job(self, job_id: str, status: JobStatus) -> None:
+        with self._lock:
+            self._jobs[job_id] = status
+
+    def get_current(self) -> dict[str, Any]:
+        with self._lock:
+            running_job = self._jobs.get(self._running_job_id) if self._running_job_id else None
+            latest = None
+            if self._jobs:
+                latest = list(self._jobs.values())[-1]
+            return {
+                "running": running_job,
+                "latest": latest,
+                "count": len(self._jobs),
+            }
+
+    def get_job(self, job_id: str) -> JobStatus:
+        with self._lock:
+            status = self._jobs.get(job_id)
+            if not status:
+                raise HTTPException(status_code=404, detail="job not found")
+            return status
+
+    def list_jobs(self) -> list[str]:
+        with self._lock:
+            return list(self._jobs.keys())
+
+    def cancel(self, job_id: str) -> JobStatus:
+        with self._lock:
+            status = self._jobs.get(job_id)
+            if not status:
+                raise HTTPException(status_code=404, detail="job not found")
+            if status.status != "running":
+                return status
+            event = self._cancel_events.get(job_id)
+            if event:
+                event.set()
+            return status
+
+
+job_manager = JobManager()
+app = FastAPI(title="panther API", version="0.1.0")
+
+
+@app.post("/jobs", response_model=JobStatus)
+async def start_job(request: JobRequest) -> JobStatus:
+    return job_manager.start_job(request)
+
+
+@app.get("/jobs")
+async def get_current_job() -> dict[str, Any]:
+    return job_manager.get_current()
+
+
+@app.get("/jobs/list", response_model=list[str])
+async def get_job_list() -> list[str]:
+    return job_manager.list_jobs()
+
+
+@app.get("/jobs/{job_id}", response_model=JobStatus)
+async def get_job(job_id: str) -> JobStatus:
+    return job_manager.get_job(job_id)
+
+
+@app.get("/jobs/{job_id}/cancel", response_model=JobStatus)
+async def cancel_job(job_id: str) -> JobStatus:
+    return job_manager.cancel(job_id)

--- a/services/panther/src/panther/upload_documents.py
+++ b/services/panther/src/panther/upload_documents.py
@@ -17,7 +17,9 @@ import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Protocol, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Protocol, Tuple
+from urllib.parse import quote, urljoin
+from urllib.request import urlopen
 
 from elasticsearch import Elasticsearch, helpers  # pip install elasticsearch
 from panther.es_client import create_es_client
@@ -29,6 +31,14 @@ from panther.patent_doc_editor import PatentDocEditor
 logger = logging.getLogger(__name__)
 
 PRESERVE_FIELDS = {"assignees", "tags", "extraNumbers"}  # user-managed fields in ES
+
+
+class UploadCancelledError(Exception):
+    """Raised when a running upload has been cancelled."""
+
+
+class UploadResult(Dict[str, int | str]):
+    pass
 
 
 class SupportsAddParser(Protocol):
@@ -44,6 +54,11 @@ def add_args(parser: SupportsAddParser) -> None:
         "--data-root",
         default="data",
         help="Root directory containing docid/document.json files (default: data)",
+    )
+    p.add_argument(
+        "--mona-base-url",
+        default=os.getenv("MONA_BASE_URL"),
+        help="Base URL of mona API server, e.g. http://localhost:8000",
     )
     p.add_argument(
         "--pipeline",
@@ -77,10 +92,29 @@ def add_args(parser: SupportsAddParser) -> None:
 
 def main(args: argparse.Namespace) -> int:
     """Upload documents to Elasticsearch."""
-    data_root = Path(args.data_root)
-    if not data_root.exists():
-        logger.error(f"Error: Data root not found: {data_root}")
+    try:
+        result = execute_upload(args)
+        logger.info(
+            f"\n[DONE] source={result['source']} Total: {result['total']}, Success: {result['success']}, Failed: {result['failed']}"
+        )
+        return 0 if result["failed"] == 0 else 1
+    except UploadCancelledError:
+        logger.warning("Upload cancelled")
         return 1
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        return 1
+
+
+def execute_upload(
+    args: argparse.Namespace,
+    should_cancel: Optional[Callable[[], bool]] = None,
+) -> UploadResult:
+    """Upload documents to Elasticsearch and return summary details."""
+    data_root = Path(args.data_root)
+    use_api = bool(args.mona_base_url)
+    if not use_api and not data_root.exists():
+        raise FileNotFoundError(f"Data root not found: {data_root}")
 
     # Connect to Elasticsearch
     logger.info(f"Connecting to Elasticsearch: {args.es}")
@@ -92,16 +126,31 @@ def main(args: argparse.Namespace) -> int:
             return 1
 
         logger.info("✓ Connected to Elasticsearch")
-        logger.info(f"Uploading documents from: {data_root}")
+        source_label = args.mona_base_url if use_api else str(data_root)
+        logger.info(f"Uploading documents from: {source_label}")
 
-        # Build actions
-        actions = build_actions(
-            index=args.index,
-            data_root=data_root,
-            pipeline=args.pipeline,
-            refresh=args.refresh,
-            use_hash_guard=args.use_hash_guard,
-        )
+        if use_api:
+            actions = list(
+                build_actions_from_mona_api(
+                    index=args.index,
+                    mona_base_url=args.mona_base_url,
+                    pipeline=args.pipeline,
+                    use_hash_guard=args.use_hash_guard,
+                    should_cancel=should_cancel,
+                )
+            )
+            source = "mona-api"
+        else:
+            actions = list(
+                build_actions_from_local(
+                    index=args.index,
+                    data_root=data_root,
+                    pipeline=args.pipeline,
+                    use_hash_guard=args.use_hash_guard,
+                    should_cancel=should_cancel,
+                )
+            )
+            source = "local"
 
         # Bulk upsert with retries
         success, failed = bulk_upsert_with_retries(
@@ -111,18 +160,19 @@ def main(args: argparse.Namespace) -> int:
             max_retries=args.max_retries,
             initial_backoff=1.0,
             max_backoff=30.0,
+            should_cancel=should_cancel,
         )
 
         if args.refresh:
             logger.info("Refreshing index...")
             es.indices.refresh(index=args.index)
 
-        logger.info(f"\n[DONE] Success: {success}, Failed: {failed}")
-        return 0 if failed == 0 else 1
-
-    except Exception as e:
-        logger.error(f"Error: {e}")
-        return 1
+        return {
+            "source": source,
+            "total": len(actions),
+            "success": success,
+            "failed": failed,
+        }
     finally:
         es.close()
 
@@ -177,83 +227,134 @@ def load_document_json(
     )
 
 
-def build_actions(
+def build_action(
+    index: str,
+    jsons: tuple[BibliographicItems, FullText, List[ImagesInformation]],
+    pipeline: Optional[str],
+    use_hash_guard: bool,
+) -> Dict:
+    _doc = PatentDocEditor(*jsons).to_es_model()
+    edited = _doc.model_dump(exclude_none=True)
+    doc = strip_preserve_fields(edited)
+
+    docid = doc["docId"]
+    ingest_hash = stable_hash(doc)
+    now = utc_now_iso()
+
+    if use_hash_guard:
+        action = {
+            "_op_type": "update",
+            "_index": index,
+            "_id": docid,
+            "retry_on_conflict": 3,
+            "scripted_upsert": True,
+            "script": {
+                "lang": "painless",
+                "source": """
+                    if (ctx._source.ingest_hash != params.ingest_hash) {
+                        // merge doc (does not delete unspecified fields)
+                        for (entry in params.doc.entrySet()) {
+                            ctx._source[entry.getKey()] = entry.getValue();
+                        }
+                        ctx._source.ingest_hash = params.ingest_hash;
+                        ctx._source.ingested_at = params.now;
+                    }
+                """,
+                "params": {"doc": doc, "ingest_hash": ingest_hash, "now": now},
+            },
+            "upsert": {
+                **doc,
+                "ingest_hash": ingest_hash,
+                "ingested_at": now,
+            },
+        }
+    else:
+        action = {
+            "_op_type": "update",
+            "_index": index,
+            "_id": docid,
+            "retry_on_conflict": 3,
+            "doc_as_upsert": True,
+            "doc": {
+                **doc,
+                "ingest_hash": ingest_hash,
+                "ingested_at": now,
+            },
+        }
+
+    if pipeline:
+        action["pipeline"] = pipeline
+
+    return action
+
+
+def _load_json_url(base_url: str, endpoint: str) -> Any:
+    url = urljoin(base_url.rstrip("/") + "/", endpoint.lstrip("/"))
+    with urlopen(url) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def load_document_json_from_mona(
+    mona_base_url: str, doc_id: str
+) -> tuple[BibliographicItems, FullText, List[ImagesInformation]]:
+    encoded_doc_id = quote(doc_id, safe="")
+    bib = _load_json_url(mona_base_url, f"/{encoded_doc_id}/json/bibliographic-items")
+    full_text = _load_json_url(mona_base_url, f"/{encoded_doc_id}/json/full-text")
+    images_info = _load_json_url(
+        mona_base_url, f"/{encoded_doc_id}/json/images-information"
+    )
+
+    images_list = images_info if isinstance(images_info, list) else [images_info]
+    return (
+        BibliographicItems(**bib),
+        FullText(**full_text),
+        [ImagesInformation(**img) for img in images_list],
+    )
+
+
+def build_actions_from_local(
     index: str,
     data_root: Path,
     pipeline: Optional[str],
-    refresh: bool,
     use_hash_guard: bool,
+    should_cancel: Optional[Callable[[], bool]] = None,
 ) -> Iterable[Dict]:
-    """
-    Generate bulk update actions.
-    """
+    """Generate bulk update actions from local files."""
     for path in iter_documents(data_root):
+        if should_cancel and should_cancel():
+            raise UploadCancelledError("Upload was cancelled before completion")
         try:
             jsons = load_document_json(path)
-            _doc = PatentDocEditor(*jsons).to_es_model()
-            edited = _doc.model_dump(exclude_none=True)
-            doc = strip_preserve_fields(edited)
-
-            # Put docid inside source too (optional but handy)
-            docid = doc["docId"]
-
-            ingest_hash = stable_hash(doc)
-            now = utc_now_iso()
-
-            if use_hash_guard:
-                # Only update when ingest_hash differs; otherwise do nothing.
-                # Still upsert if missing.
-                action = {
-                    "_op_type": "update",
-                    "_index": index,
-                    "_id": docid,
-                    "retry_on_conflict": 3,
-                    "scripted_upsert": True,
-                    "script": {
-                        "lang": "painless",
-                        "source": """
-                            if (ctx._source.ingest_hash != params.ingest_hash) {
-                                // merge doc (does not delete unspecified fields)
-                                for (entry in params.doc.entrySet()) {
-                                    ctx._source[entry.getKey()] = entry.getValue();
-                                }
-                                ctx._source.ingest_hash = params.ingest_hash;
-                                ctx._source.ingested_at = params.now;
-                            }
-                        """,
-                        "params": {"doc": doc, "ingest_hash": ingest_hash, "now": now},
-                    },
-                    "upsert": {
-                        **doc,
-                        "ingest_hash": ingest_hash,
-                        "ingested_at": now,
-                    },
-                }
-            else:
-                # Simple partial update + upsert.
-                action = {
-                    "_op_type": "update",
-                    "_index": index,
-                    "_id": docid,
-                    "retry_on_conflict": 3,
-                    "doc_as_upsert": True,
-                    "doc": {
-                        **doc,
-                        "ingest_hash": ingest_hash,
-                        "ingested_at": now,
-                    },
-                }
-
-            if pipeline:
-                action["pipeline"] = pipeline
-
-            # `refresh` is controlled outside bulk (safer). Kept here for compatibility if needed.
-            # helpers.bulk doesn't accept per-action refresh; ignore.
-
-            yield action
-
+            yield build_action(index, jsons, pipeline, use_hash_guard)
+        except UploadCancelledError:
+            raise
         except Exception as e:
             logger.error(f"[ERROR] {path}: {e}")
+            continue
+
+
+def build_actions_from_mona_api(
+    index: str,
+    mona_base_url: str,
+    pipeline: Optional[str],
+    use_hash_guard: bool,
+    should_cancel: Optional[Callable[[], bool]] = None,
+) -> Iterable[Dict]:
+    """Generate bulk update actions from mona REST API."""
+    id_list_payload = _load_json_url(mona_base_url, "/idList")
+    doc_ids = json.loads(id_list_payload) if isinstance(id_list_payload, str) else id_list_payload
+    if not isinstance(doc_ids, list):
+        raise ValueError("mona /idList response must be list[str]")
+
+    for doc_id in doc_ids:
+        if should_cancel and should_cancel():
+            raise UploadCancelledError("Upload was cancelled before completion")
+        try:
+            jsons = load_document_json_from_mona(mona_base_url, str(doc_id))
+            yield build_action(index, jsons, pipeline, use_hash_guard)
+
+        except Exception as e:
+            logger.error(f"[ERROR] doc_id={doc_id}: {e}")
             continue
 
 
@@ -264,6 +365,7 @@ def bulk_upsert_with_retries(
     max_retries: int,
     initial_backoff: float,
     max_backoff: float,
+    should_cancel: Optional[Callable[[], bool]] = None,
 ) -> Tuple[int, int]:
     """
     Bulk upsert with retry/backoff for transient errors.
@@ -298,6 +400,8 @@ def bulk_upsert_with_retries(
                 ok_count += 1
             else:
                 errors_accum.append(item)
+            if should_cancel and should_cancel():
+                raise UploadCancelledError("Upload was cancelled during bulk request")
 
         if not errors_accum:
             success += ok_count


### PR DESCRIPTION
### Motivation
- Replace local-file-only ingestion with the ability to fetch document JSON from the mona REST API (`/idList`, `/{doc_id}/json/*`) so uploads can run against a running mona server. 
- Provide a simple REST interface to start/monitor/cancel upload jobs so uploads can be triggered programmatically instead of only from the CLI. 
- Make the upload flow reusable between CLI and server, and add cooperative cancellation to allow interrupting long-running jobs.

### Description
- Extended `upload_documents.py` to accept `--mona-base-url` and implemented `build_actions_from_mona_api`, `load_document_json_from_mona`, and `_load_json_url` to fetch `bibliographic-items`, `full-text` and `images-information` from the mona API. 
- Refactored CLI upload flow into `execute_upload(...)` which returns a summary (`source/total/success/failed`) and added `UploadCancelledError` plus a `should_cancel` callback to support cancellation during iteration and bulk operations. 
- Split per-document action construction into `build_action(...)` and preserved existing hash-guard/upsert behavior and pipeline handling. 
- Added `services/panther/src/panther/server.py` implementing a small FastAPI job server and `JobManager` that supports `POST /jobs`, `GET /jobs`, `GET /jobs/list`, `GET /jobs/{job_id}`, and `GET /jobs/{job_id}/cancel` with running/completed/failed/cancelled states and basic metrics. 
- Updated `services/panther/README.md` with usage examples for `--mona-base-url` ingestion and how to run the Panther REST API (`uvicorn panther.server:app`).

### Testing
- Ran Python byte-compilation for the modified files with `python -m compileall services/panther/src/panther/upload_documents.py services/panther/src/panther/server.py` and it completed successfully. 
- Ran static checks with `ruff check services/panther/src/panther/upload_documents.py services/panther/src/panther/server.py` and the checks passed. 
- Attempted a quick runtime import using `PYTHONPATH=services/panther/src python -c 'from panther.server import app; print(app.title)'` which failed with `ModuleNotFoundError: No module named 'fastapi'`, so full runtime tests require the `fastapi`/`uvicorn` dependencies to be installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c374094d608323852cb99168ba1a48)