### PR TITLE
Add schedule-based Crow crawl execution in Navi admin

### DIFF
--- a/services/navi/src/navi/crow_scheduler.py
+++ b/services/navi/src/navi/crow_scheduler.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, time, timedelta
+from typing import Any, Literal
+
+from navi.crow_client import CrowClient, CrowClientError
+
+ScheduleType = Literal["daily", "interval"]
+
+
+@dataclass
+class CrowSchedule:
+    id: str
+    schedule_type: ScheduleType
+    payload: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    next_run_at: datetime
+    daily_time: str | None = None
+    interval_minutes: int | None = None
+    enabled: bool = True
+    last_run_at: datetime | None = None
+    last_result: str | None = None
+    last_message: str | None = None
+
+
+class CrowScheduleError(Exception):
+    pass
+
+
+class CrowScheduleManager:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._schedules: dict[str, CrowSchedule] = {}
+
+    async def list_schedules(self) -> list[CrowSchedule]:
+        async with self._lock:
+            return sorted(self._schedules.values(), key=lambda s: s.created_at)
+
+    async def create_schedule(
+        self,
+        *,
+        schedule_type: ScheduleType,
+        payload: dict[str, Any],
+        daily_time: str | None,
+        interval_minutes: int | None,
+    ) -> CrowSchedule:
+        now = datetime.now(UTC)
+        schedule_id = str(uuid.uuid4())
+        next_run_at = _compute_next_run(
+            schedule_type=schedule_type,
+            now=now,
+            daily_time=daily_time,
+            interval_minutes=interval_minutes,
+        )
+        schedule = CrowSchedule(
+            id=schedule_id,
+            schedule_type=schedule_type,
+            payload=payload,
+            created_at=now,
+            updated_at=now,
+            next_run_at=next_run_at,
+            daily_time=daily_time,
+            interval_minutes=interval_minutes,
+        )
+        async with self._lock:
+            self._schedules[schedule_id] = schedule
+        return schedule
+
+    async def delete_schedule(self, schedule_id: str) -> bool:
+        async with self._lock:
+            return self._schedules.pop(schedule_id, None) is not None
+
+    async def toggle_schedule(self, schedule_id: str) -> CrowSchedule:
+        async with self._lock:
+            schedule = self._schedules.get(schedule_id)
+            if schedule is None:
+                raise CrowScheduleError("指定された予約ジョブは存在しません。")
+            schedule.enabled = not schedule.enabled
+            schedule.updated_at = datetime.now(UTC)
+            if schedule.enabled:
+                schedule.next_run_at = _compute_next_run(
+                    schedule_type=schedule.schedule_type,
+                    now=schedule.updated_at,
+                    daily_time=schedule.daily_time,
+                    interval_minutes=schedule.interval_minutes,
+                )
+            return schedule
+
+    async def run_pending(self) -> None:
+        now = datetime.now(UTC)
+        async with self._lock:
+            due_ids = [
+                schedule.id
+                for schedule in self._schedules.values()
+                if schedule.enabled and schedule.next_run_at <= now
+            ]
+
+        for schedule_id in due_ids:
+            await self._run_schedule(schedule_id)
+
+    async def _run_schedule(self, schedule_id: str) -> None:
+        async with self._lock:
+            schedule = self._schedules.get(schedule_id)
+            if schedule is None or not schedule.enabled:
+                return
+            payload = dict(schedule.payload)
+
+        client = CrowClient()
+        now = datetime.now(UTC)
+        try:
+            response = client.start_job(payload)
+            status = response.get("status", "unknown")
+            message = response.get("message") or f"job_id={response.get('job_id', '-') }"
+            result = f"ok:{status}"
+        except CrowClientError as exc:
+            message = str(exc)
+            result = "error"
+
+        async with self._lock:
+            schedule = self._schedules.get(schedule_id)
+            if schedule is None:
+                return
+            schedule.last_run_at = now
+            schedule.last_result = result
+            schedule.last_message = message
+            schedule.updated_at = now
+            schedule.next_run_at = _compute_next_run(
+                schedule_type=schedule.schedule_type,
+                now=now,
+                daily_time=schedule.daily_time,
+                interval_minutes=schedule.interval_minutes,
+            )
+
+
+@dataclass
+class CrowScheduleRunner:
+    manager: CrowScheduleManager
+    interval_seconds: int = 15
+    _task: asyncio.Task[None] | None = field(default=None, init=False)
+
+    def start(self) -> None:
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+
+    async def _loop(self) -> None:
+        while True:
+            await self.manager.run_pending()
+            await asyncio.sleep(self.interval_seconds)
+
+
+def _compute_next_run(
+    *,
+    schedule_type: ScheduleType,
+    now: datetime,
+    daily_time: str | None,
+    interval_minutes: int | None,
+) -> datetime:
+    if schedule_type == "daily":
+        if daily_time is None:
+            raise CrowScheduleError("daily schedule には時刻指定が必要です。")
+        hour, minute = _parse_daily_time(daily_time)
+        candidate = datetime.combine(now.date(), time(hour=hour, minute=minute, tzinfo=UTC))
+        if candidate <= now:
+            candidate += timedelta(days=1)
+        return candidate
+
+    if interval_minutes is None or interval_minutes <= 0:
+        raise CrowScheduleError("interval schedule には正の分指定が必要です。")
+    return now + timedelta(minutes=interval_minutes)
+
+
+def _parse_daily_time(value: str) -> tuple[int, int]:
+    parts = value.split(":")
+    if len(parts) != 2:
+        raise CrowScheduleError("毎日実行時刻は HH:MM 形式で指定してください。")
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+    except ValueError as exc:
+        raise CrowScheduleError("毎日実行時刻は HH:MM 形式で指定してください。") from exc
+    if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+        raise CrowScheduleError("毎日実行時刻は HH:MM 形式で指定してください。")
+    return hour, minute

--- a/services/navi/src/navi/routers/crow.py
+++ b/services/navi/src/navi/routers/crow.py
@@ -6,6 +6,7 @@ from urllib import parse
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
 from navi.crow_client import CrowClient, CrowClientError, get_crow_config
+from navi.crow_scheduler import CrowScheduleError, CrowScheduleManager
 from navi.ui import templates
 from starlette.datastructures import UploadFile
 
@@ -43,7 +44,20 @@ def _to_datetime_string(timestamp: float | int | None) -> str | None:
     return datetime.fromtimestamp(timestamp, tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
-def _build_page_context(
+def _format_datetime(value: datetime | None) -> str:
+    if value is None:
+        return "-"
+    return value.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _get_schedule_manager(request: Request) -> CrowScheduleManager:
+    manager = getattr(request.app.state, "schedule_manager", None)
+    if manager is None:
+        raise RuntimeError("schedule_manager is not configured")
+    return manager
+
+
+async def _build_page_context(
     *,
     request: Request,
     flash: str | None = None,
@@ -57,6 +71,7 @@ def _build_page_context(
     doc_code_categories: list[dict] = []
     selected_log = None
     selected_log_pretty = None
+    schedules = []
 
     try:
         status = client.get_status()
@@ -85,6 +100,11 @@ def _build_page_context(
         except CrowClientError as exc:
             error_message = error_message or _format_error_message(exc)
 
+    try:
+        schedules = await _get_schedule_manager(request).list_schedules()
+    except Exception as exc:  # noqa: BLE001
+        error_message = error_message or _format_error_message(exc)
+
     return {
         "request": request,
         "flash": flash,
@@ -98,6 +118,8 @@ def _build_page_context(
         "selected_log": selected_log,
         "selected_log_pretty": selected_log_pretty,
         "format_timestamp": _to_datetime_string,
+        "format_datetime": _format_datetime,
+        "schedules": schedules,
         "form_doc_id": "",
         "form_max_files": "",
         "form_doc_codes": [],
@@ -106,7 +128,7 @@ def _build_page_context(
 
 
 @router.get("/", name="crow")
-def crow_admin(
+async def crow_admin(
     request: Request,
     message: str | None = Query(default=None),
     error: str | None = Query(default=None),
@@ -114,7 +136,7 @@ def crow_admin(
 ):
     return templates.TemplateResponse(
         "crow/index.html",
-        _build_page_context(
+        await _build_page_context(
             request=request,
             flash=message,
             error_message=error,
@@ -124,7 +146,7 @@ def crow_admin(
 
 
 @router.get("/{job_id}", name="crow_detail")
-def crow_admin(
+async def crow_admin_detail(
     request: Request,
     job_id: str,
     message: str | None = Query(default=None),
@@ -132,7 +154,7 @@ def crow_admin(
 ):
     return templates.TemplateResponse(
         "crow/index.html",
-        _build_page_context(
+        await _build_page_context(
             request=request,
             flash=message,
             error_message=error,
@@ -172,7 +194,7 @@ async def start_crow_job(request: Request):
         return templates.TemplateResponse(
             "crow/index.html",
             {
-                **_build_page_context(
+                **await _build_page_context(
                     request=request,
                     error_message=_format_error_message(exc),
                 ),
@@ -212,4 +234,84 @@ def cancel_crow_job(request: Request):
     if message:
         flash = f"{flash}, message={message}"
     u = request.url_for("crow", message=parse.quote(flash))
+    return RedirectResponse(url=u, status_code=303)
+
+
+@router.post("/schedules", name="crow_schedule_create")
+async def create_crow_schedule(request: Request):
+    form = await request.form()
+    selected_doc_codes = _normalize_doc_codes(form.getlist("doc_codes"))
+    payload: dict[str, Any] = {
+        "overwrite": _parse_checkbox(_form_value_as_str(form.get("overwrite"))),
+        "max_files": None,
+        "doc_id": None,
+        "doc_codes": selected_doc_codes,
+    }
+
+    max_files_value = str(form.get("max_files", "")).strip()
+    if max_files_value:
+        try:
+            payload["max_files"] = int(max_files_value)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="max_files must be an integer"
+            ) from exc
+
+    doc_id_value = str(form.get("doc_id", "")).strip()
+    if doc_id_value:
+        payload["doc_id"] = doc_id_value
+
+    schedule_type = str(form.get("schedule_type", "daily")).strip()
+    if schedule_type not in {"daily", "interval"}:
+        raise HTTPException(status_code=400, detail="invalid schedule_type")
+
+    daily_time = str(form.get("daily_time", "")).strip() or None
+    interval_minutes_raw = str(form.get("interval_minutes", "")).strip()
+    interval_minutes = None
+    if interval_minutes_raw:
+        try:
+            interval_minutes = int(interval_minutes_raw)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="interval_minutes must be an integer"
+            ) from exc
+
+    manager = _get_schedule_manager(request)
+    try:
+        schedule = await manager.create_schedule(
+            schedule_type=schedule_type,
+            payload=payload,
+            daily_time=daily_time,
+            interval_minutes=interval_minutes,
+        )
+    except CrowScheduleError as exc:
+        u = request.url_for("crow", error=parse.quote(_format_error_message(exc)))
+        return RedirectResponse(url=u, status_code=303)
+
+    flash = f"予約ジョブを作成しました: schedule_id={schedule.id}, next_run={_format_datetime(schedule.next_run_at)}"
+    u = request.url_for("crow", message=parse.quote(flash))
+    return RedirectResponse(url=u, status_code=303)
+
+
+@router.post("/schedules/{schedule_id}/delete", name="crow_schedule_delete")
+async def delete_crow_schedule(request: Request, schedule_id: str):
+    deleted = await _get_schedule_manager(request).delete_schedule(schedule_id)
+    if not deleted:
+        u = request.url_for("crow", error=parse.quote("指定された予約ジョブは存在しません。"))
+        return RedirectResponse(url=u, status_code=303)
+    u = request.url_for("crow", message=parse.quote(f"予約ジョブを削除しました: {schedule_id}"))
+    return RedirectResponse(url=u, status_code=303)
+
+
+@router.post("/schedules/{schedule_id}/toggle", name="crow_schedule_toggle")
+async def toggle_crow_schedule(request: Request, schedule_id: str):
+    manager = _get_schedule_manager(request)
+    try:
+        schedule = await manager.toggle_schedule(schedule_id)
+    except CrowScheduleError as exc:
+        u = request.url_for("crow", error=parse.quote(_format_error_message(exc)))
+        return RedirectResponse(url=u, status_code=303)
+
+    state = "有効化" if schedule.enabled else "無効化"
+    u = request.url_for("crow", message=parse.quote(f"予約ジョブを{state}しました: {schedule_id}"))
     return RedirectResponse(url=u, status_code=303)

--- a/services/navi/src/navi/server.py
+++ b/services/navi/src/navi/server.py
@@ -1,8 +1,26 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
+from navi.crow_scheduler import CrowScheduleManager, CrowScheduleRunner
 from navi.routers import crow, dashboard, mona, orchestration, panther
 
-app = FastAPI(title="Navi Admin", root_path="/navi")
+schedule_manager = CrowScheduleManager()
+schedule_runner = CrowScheduleRunner(manager=schedule_manager)
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    schedule_runner.start()
+    try:
+        yield
+    finally:
+        await schedule_runner.stop()
+
+
+app = FastAPI(title="Navi Admin", root_path="/navi", lifespan=lifespan)
+
+app.state.schedule_manager = schedule_manager
 
 app.include_router(dashboard.router)
 app.include_router(crow.router)

--- a/services/navi/src/navi/templates/crow/index.html
+++ b/services/navi/src/navi/templates/crow/index.html
@@ -91,6 +91,8 @@
 
         input[type="text"],
         input[type="number"],
+        input[type="time"],
+        select,
         select[multiple] {
             width: 100%;
             box-sizing: border-box;
@@ -103,6 +105,12 @@
 
         select[multiple] {
             min-height: 14rem;
+        }
+
+        .inline-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 0.75rem;
         }
 
         .field-hint {
@@ -238,6 +246,49 @@
                 </form>
             </article>
 
+
+            <article class="panel">
+                <h2>定期実行予約（Cron 風）</h2>
+                <form method="post" action="{{ url_for('crow_schedule_create') }}">
+                    <label for="schedule_type">実行方式</label>
+                    <select id="schedule_type" name="schedule_type">
+                        <option value="daily">毎日指定時刻（UTC）</option>
+                        <option value="interval">定期間隔（分）</option>
+                    </select>
+
+                    <div class="inline-grid">
+                        <div>
+                            <label for="daily_time">毎日実行時刻 (HH:MM)</label>
+                            <input id="daily_time" name="daily_time" type="time" value="03:00">
+                        </div>
+                        <div>
+                            <label for="interval_minutes">間隔（分）</label>
+                            <input id="interval_minutes" name="interval_minutes" type="number" min="1" placeholder="例: 60">
+                        </div>
+                    </div>
+
+                    <label for="schedule_doc_id">doc_id</label>
+                    <input id="schedule_doc_id" name="doc_id" type="text" placeholder="例: JP-2026-000001">
+
+                    <label for="schedule_max_files">max_files</label>
+                    <input id="schedule_max_files" name="max_files" type="number" min="0" placeholder="例: 100">
+
+                    <label for="schedule_doc_codes">doc_codes</label>
+                    <select id="schedule_doc_codes" name="doc_codes" multiple size="8">
+                        {% for code in available_doc_codes %}
+                        <option value="{{ code }}">{{ code }}</option>
+                        {% endfor %}
+                    </select>
+
+                    <div class="checkbox">
+                        <input id="schedule_overwrite" name="overwrite" type="checkbox">
+                        <label for="schedule_overwrite">既存ファイルがあっても上書きして crawl する</label>
+                    </div>
+
+                    <button type="submit">予約を作成</button>
+                </form>
+            </article>
+
             <article class="panel">
                 <h2>現在の状態</h2>
                 {% if status %}
@@ -315,6 +366,59 @@
                 {% endif %}
             </article>
         </section>
+
+
+        <section class="panel" style="margin-top: 1rem;">
+            <h2>予約ジョブ一覧</h2>
+            {% if schedules %}
+            <div style="overflow-x:auto;">
+                <table style="width: 100%; border-collapse: collapse;">
+                    <thead>
+                        <tr>
+                            <th style="text-align:left; border-bottom: 1px solid var(--border);">schedule_id</th>
+                            <th style="text-align:left; border-bottom: 1px solid var(--border);">方式</th>
+                            <th style="text-align:left; border-bottom: 1px solid var(--border);">次回実行</th>
+                            <th style="text-align:left; border-bottom: 1px solid var(--border);">前回結果</th>
+                            <th style="text-align:left; border-bottom: 1px solid var(--border);">状態</th>
+                            <th style="text-align:left; border-bottom: 1px solid var(--border);">操作</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for schedule in schedules %}
+                        <tr>
+                            <td><code>{{ schedule.id }}</code></td>
+                            <td>
+                                {% if schedule.schedule_type == 'daily' %}
+                                毎日 {{ schedule.daily_time }} UTC
+                                {% else %}
+                                {{ schedule.interval_minutes }}分ごと
+                                {% endif %}
+                            </td>
+                            <td>{{ format_datetime(schedule.next_run_at) }}</td>
+                            <td>
+                                {{ schedule.last_result or '-' }}<br>
+                                <span class="muted">{{ format_datetime(schedule.last_run_at) }}</span><br>
+                                <span class="muted">{{ schedule.last_message or '' }}</span>
+                            </td>
+                            <td>{{ '有効' if schedule.enabled else '無効' }}</td>
+                            <td>
+                                <form method="post" action="{{ url_for('crow_schedule_toggle', schedule_id=schedule.id) }}" style="display:inline-block; margin-right:0.4rem;">
+                                    <button class="secondary" type="submit">{{ '無効化' if schedule.enabled else '有効化' }}</button>
+                                </form>
+                                <form method="post" action="{{ url_for('crow_schedule_delete', schedule_id=schedule.id) }}" style="display:inline-block;">
+                                    <button type="submit">削除</button>
+                                </form>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <p class="muted">予約ジョブはまだありません。</p>
+            {% endif %}
+        </section>
+
 
         <section class="panel" style="margin-top: 1rem;">
             <h2>ジョブログ</h2>


### PR DESCRIPTION
### Motivation
- Provide a cron-like scheduling UI so Crow crawling jobs can be scheduled to run automatically at specified times or intervals with the same job parameters used by the manual UI. 
- Persist schedule state in-process and execute due schedules by invoking Crow's `/jobs` API with the saved payload. 

### Description
- Add `services/navi/src/navi/crow_scheduler.py` implementing `CrowSchedule`, an in-memory `CrowScheduleManager`, and `CrowScheduleRunner` that polls every 15s and calls `CrowClient.start_job` for due schedules. 
- Wire scheduler lifecycle into FastAPI `lifespan` and expose the manager on `app.state` in `services/navi/src/navi/server.py`. 
- Extend `services/navi/src/navi/routers/crow.py` to include endpoints `POST /crow/schedules`, `POST /crow/schedules/{id}/delete`, and `POST /crow/schedules/{id}/toggle`, add schedule listing to page context, and validate schedule input (`daily` HH:MM or `interval` minutes). 
- Update `services/navi/src/navi/templates/crow/index.html` to add a schedule creation form (daily time or interval) and a schedule table showing next run, last result/message, and actions (toggle/delete). 
- Scheduler state is process-local (in-memory), and next-run calculation/validation is implemented (`HH:MM` parsing, positive-interval checks). 

### Testing
- Ran `cd services/navi && python -m compileall src/navi`, which completed successfully. 
- No additional automated tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d68e72747083238dd5e80bcdca1a3c)